### PR TITLE
Fixed bug in probe(addr, cb) to support osx

### DIFF
--- a/lib/ping-sys.js
+++ b/lib/ping-sys.js
@@ -25,8 +25,8 @@ function probe(addr, cb) {
             var ls = spawn('C:/windows/system32/ping.exe', ['-n', '1', '-w', '5000', addr]);
 
         } else if (p == 'darwin') {
-            //mac ox
-            var ls = spawn('/sbin/ping', ['-n', '-t 2', '-c 1', addr]);
+            //mac osx
+            var ls = cp.spawn('/sbin/ping', ['-n', '-t 2', '-c 1', addr]);
         }
 
         ls.on('error', function(e) {


### PR DESCRIPTION
The probe function in `ping-sys.js` did not work on Mac OSX because you need to use the spawn method of `child_process` module.

I tested with node v0.8.20 and everything works fine with that bug fix.
