### PR TITLE
Update ping-sys.js

### DIFF
--- a/lib/ping-sys.js
+++ b/lib/ping-sys.js
@@ -69,7 +69,6 @@ function probe(addr, cb) {
                     }
                 }
                 */
-                }
             }
             else {
                 result = (code === 0 ? true : false);


### PR DESCRIPTION
It is not working on my Chinese Windows8 64bit. I found that when destination is alive, there must be a (0% xxxx) in the result, so I decided to used that as a mark value.
