### PR TITLE
Catch keyword TTL instead of round-trip time

### DIFF
--- a/lib/ping-promise.js
+++ b/lib/ping-promise.js
@@ -113,7 +113,7 @@ function probe(addr, config) {
             // this is my solution on Chinese Windows8 64bit
             result  = false;
             for (var t = 0; t < lines.length; t++) {
-                if (lines[t].indexOf('round trip time') > 0) {
+                if (lines[t].search(/TTL=[0-9]+/i) > 0) {
                     result	= true;
                     break;
                 }

--- a/lib/ping-sys.js
+++ b/lib/ping-sys.js
@@ -60,7 +60,7 @@ function probe(addr, cb) {
                 var lines = outstring.split('\n');
                 result  = false;
                 for (var t = 0; t < lines.length; t++) {
-                    if (lines[t].indexOf('round trip time') > 0) {
+                    if (lines[t].search(/TTL=[0-9]+/i) > 0) {
 						result	= true;
 						break;
 					}


### PR DESCRIPTION
--Overview
1. According to Issue #17, catching `TTL` is better than catching

``` rountd-trip```
```
