### PR TITLE
Set default arguments for MAC OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,15 @@ npm install ping
             });
     });
 
+### Support configuration
+
+```
+/**
+ * Cross platform config representation
+ * @typedef {Object} PingConfig
+ * @property {boolean} numeric - Map IP address to hostname or not
+ * @property {number} timeout - Time duration for ping command to exit
+ * @property {number} min_reply - Exit after sending number of ECHO_REQUEST
+ * @property {string[]} extra - Optional options does not provided
+ */
+```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Below are examples extracted from `examples`
 
 ##Promise Wrapper with configable ping options
 
-    //Only promise wrapper supports configable ping options
     hosts.forEach(function (host) {
         // WARNING: -i 2 argument may not work in other platform like window
         ping.promise.probe(host, {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 #NODE-PING
 a ping wrapper for nodejs
 
+@last-modified: 2016-01-23 00:36
+
 #LICENSE MIT
 
 (C) Daniel Zelisko
@@ -16,6 +18,8 @@ node-ping is a simple wrapper for the system ping utility
 npm install ping
 
 #USAGE
+
+Below are examples extracted from `examples`
 
 ##Tradition calls
 
@@ -46,15 +50,18 @@ npm install ping
 
     //Only promise wrapper supports configable ping options
     hosts.forEach(function (host) {
+        // WARNING: -i 2 argument may not work in other platform like window
         ping.promise.probe(host, {
             timeout: 10,
-            extra: ["-i 2"]
+            extra: ["-i 2"],
         }).then(function (res) {
-                console.log(res);
-            });
+            console.log(res);
+        });
     });
 
 ### Support configuration
+
+Below is the possible configuration
 
 ```
 /**
@@ -66,3 +73,15 @@ npm install ping
  * @property {string[]} extra - Optional options does not provided
  */
 ```
+
+#### Note
+
+* Since `ping` in this module relies on the `ping` from underlying platform,
+arguments in `PingConfig.extra` will definitely be varied across different
+platforms.
+
+* However, `numeric`, `timeout` and `min_reply` have been abstracted. Values for
+them are expected to be cross platform.
+
+* By setting `numeric`, `timeout` or `min_reply` to false, you can run `ping`
+without corresponding arguments.

--- a/examples/example.js
+++ b/examples/example.js
@@ -4,9 +4,22 @@ var ping = require('../index');
 
 var hosts = ['192.168.1.1', 'google.com', 'yahoo.com'];
 hosts.forEach(function(host){
+    // Running with default config
     ping.sys.probe(host, function(isAlive){
         var msg = isAlive ? 'host ' + host + ' is alive' : 'host ' + host + ' is dead';
         console.log(msg);
     });
+
+    // Running with custom config
+    ping.sys.probe(host, function(isAlive){
+        var msg = isAlive ? 'host ' + host + ' is alive' : 'host ' + host + ' is dead';
+        console.log(msg);
+    }, {extra: ["-i 2"]});
+
+    // Running ping with some default argument gone
+    ping.sys.probe(host, function(isAlive){
+        var msg = isAlive ? 'host ' + host + ' is alive' : 'host ' + host + ' is dead';
+        console.log(msg);
+    }, {extra: ["-i 2"], timeout: false});
 });
 

--- a/examples/example2.js
+++ b/examples/example2.js
@@ -2,6 +2,7 @@ var ping = require("../index");
 
 var hosts = ['192.168.1.1', 'google.com', 'yahoo.com'];
 
+// Running with default config
 hosts.forEach(function (host) {
     ping.promise.probe(host)
         .then(function (res) {
@@ -10,7 +11,9 @@ hosts.forEach(function (host) {
         .done();
 });
 
+// Running with custom config
 hosts.forEach(function (host) {
+    // WARNING: -i 2 argument may not work in other platform like window
     ping.promise.probe(host, {
         timeout: 10,
         extra: ["-i", "2"]

--- a/examples/example2.js
+++ b/examples/example2.js
@@ -16,10 +16,24 @@ hosts.forEach(function (host) {
     // WARNING: -i 2 argument may not work in other platform like window
     ping.promise.probe(host, {
         timeout: 10,
-        extra: ["-i", "2"]
+        extra: ["-i 2"],
     })
     .then(function (res) {
-            console.log(res);
+        console.log(res);
+    })
+    .done();
+});
+
+// Running ping with some default argument gone
+hosts.forEach(function (host) {
+    // WARNING: -i 2 argument may not work in other platform like window
+    ping.promise.probe(host, {
+        timeout: false,
+        // Below extra arguments may not work in platforms other than linux
+        extra: ["-i 2"],
+    })
+    .then(function (res) {
+        console.log(res);
     })
     .done();
 });

--- a/lib/builder/linux.js
+++ b/lib/builder/linux.js
@@ -1,0 +1,66 @@
+/**
+ * A builder builds command line arguments for ping in linux environment
+ * @module lib/builder/linux
+ */
+var util = require('util');
+var ret = {};
+
+/**
+ * Cross platform config representation
+ * @typedef {Object} PingConfig
+ * @property {boolean} numeric - Map IP address to hostname or not
+ * @property {number} timeout - Time duration for ping command to exit
+ * @property {number} min_reply - Exit after sending number of ECHO_REQUEST
+ * @property {string[]} extra - Optional options does not provided
+ */
+
+var defaultConfig = {
+    'numeric': true,
+    'timeout': 2,
+    'min_reply': 1,
+    'extra': []
+};
+
+/**
+ * Get the finalized array of command line arguments
+ * @param {string} target - hostname or ip address
+ * @param {PingConfig} [config] - Configuration object for cmd line argument
+ * @return {string[]} - Command line argument according to the configuration
+ */
+ret.getResult = function (target, config) {
+    config = config || {};
+
+    // Empty argument
+    var ret = [];
+
+    // Make every key in config has been setup properly
+    var keys = ['numeric', 'timeout', 'min_reply', 'extra'];
+    keys.forEach(function (k) {
+        // Falsy value will be overrided without below checking
+        if (typeof(config[k]) !== 'boolean') {
+            config[k] = config[k] || defaultConfig[k];
+        }
+    });
+
+    if (config.numeric) {
+        ret.push('-n');
+    }
+
+    if (config.timeout) {
+        ret.push(util.format('-w %d', config.timeout));
+    }
+
+    if (config.min_reply) {
+        ret.push(util.format('-c %d', config.min_reply));
+    }
+
+    if (config.extra) {
+        ret = ret.concat(config.extra);
+    }
+
+    ret.push(target);
+
+    return ret;
+};
+
+module.exports = ret;

--- a/lib/builder/mac.js
+++ b/lib/builder/mac.js
@@ -1,0 +1,66 @@
+/**
+ * A builder builds command line arguments for ping in mac environment
+ * @module lib/builder/mac
+ */
+var util = require('util');
+var ret = {};
+
+/**
+ * Cross platform config representation
+ * @typedef {Object} PingConfig
+ * @property {boolean} numeric - Map IP address to hostname or not
+ * @property {number} timeout - Time duration for ping command to exit
+ * @property {number} min_reply - Exit after sending number of ECHO_REQUEST
+ * @property {string[]} extra - Optional options does not provided
+ */
+
+var defaultConfig = {
+    'numeric': true,
+    'timeout': 2,
+    'min_reply': 1,
+    'extra': []
+};
+
+/**
+ * Get the finalized array of command line arguments
+ * @param {string} target - hostname or ip address
+ * @param {PingConfig} [config] - Configuration object for cmd line argument
+ * @return {string[]} - Command line argument according to the configuration
+ */
+ret.getResult = function (target, config) {
+    config = config || {};
+
+    // Empty argument
+    var ret = [];
+
+    // Make every key in config has been setup properly
+    var keys = ['numeric', 'timeout', 'min_reply', 'extra'];
+    keys.forEach(function (k) {
+        // Falsy value will be overrided without below checking
+        if (typeof(config[k]) !== 'boolean') {
+            config[k] = config[k] || defaultConfig[k];
+        }
+    });
+
+    if (config.numeric) {
+        ret.push('-n');
+    }
+
+    if (config.timeout) {
+        ret.push(util.format('-t %d', config.timeout));
+    }
+
+    if (config.min_reply) {
+        ret.push(util.format('-c %d', config.min_reply));
+    }
+
+    if (config.extra) {
+        ret = ret.concat(config.extra);
+    }
+
+    ret.push(target);
+
+    return ret;
+};
+
+module.exports = ret;

--- a/lib/builder/win.js
+++ b/lib/builder/win.js
@@ -1,0 +1,66 @@
+/**
+ * A builder builds command line arguments for ping in window environment
+ * @module lib/builder/win
+ */
+var util = require('util');
+var ret = {};
+
+/**
+ * Cross platform config representation
+ * @typedef {Object} PingConfig
+ * @property {boolean} numeric - Map IP address to hostname or not
+ * @property {number} timeout - Time duration for ping command to exit
+ * @property {number} min_reply - Exit after sending number of ECHO_REQUEST
+ * @property {string[]} extra - Optional options does not provided
+ */
+
+var defaultConfig = {
+    'numeric': true,
+    'timeout': 5,
+    'min_reply': 1,
+    'extra': []
+};
+
+/**
+ * Get the finalized array of command line arguments
+ * @param {string} target - hostname or ip address
+ * @param {PingConfig} [config] - Configuration object for cmd line argument
+ * @return {string[]} - Command line argument according to the configuration
+ */
+ret.getResult = function (target, config) {
+    config = config || {};
+
+    // Empty argument
+    var ret = [];
+
+    // Make every key in config has been setup properly
+    var keys = ['numeric', 'timeout', 'min_reply', 'extra'];
+    keys.forEach(function (k) {
+        // Falsy value will be overrided without below checking
+        if (typeof(config[k]) !== 'boolean') {
+            config[k] = config[k] || defaultConfig[k];
+        }
+    });
+
+    if (config.numeric) {
+        ret.push('-n');
+    }
+
+    if (config.timeout) {
+        ret.push(util.format('-w %d', config.timeout * 1000));
+    }
+
+    if (config.min_reply) {
+        ret.push(util.format('-n %d', config.min_reply));
+    }
+
+    if (config.extra) {
+        ret = ret.concat(config.extra);
+    }
+
+    ret.push(target);
+
+    return ret;
+};
+
+module.exports = ret;

--- a/lib/builder/win.js
+++ b/lib/builder/win.js
@@ -42,8 +42,8 @@ ret.getResult = function (target, config) {
         }
     });
 
-    if (config.numeric) {
-        ret.push('-n');
+    if (!config.numeric) {
+        ret.push('-a');
     }
 
     if (config.timeout) {

--- a/lib/ping-promise.js
+++ b/lib/ping-promise.js
@@ -16,6 +16,11 @@ var sys = require('util'),
 //3rd-party library
 var Q = require("q");
 
+// Our library
+var linuxBuilder = require('./builder/linux');
+var macBuilder = require('./builder/mac');
+var winBuilder = require('./builder/win');
+
 /**
  * Class::PromisePing
  *
@@ -32,70 +37,21 @@ function probe(addr, config) {
     var ls = null;
     var outstring = "";
     var deferred = Q.defer();
-    var default_cfg = {
-        "numeric": true,
-        "timeout": 2,
-        "min_reply": 1,
-        "extra": []
-    };
     var args = [];
-    config = config ? config : default_cfg;
+    config = config ? config : {};
 
     if (p === 'linux') {
         //linux
-        args = [];
-        if (config.numeric !== false) {
-            args.push("-n");
-        }
-        if (config.timeout !== false) {
-            args.push(sys.format("-w %d",
-                        config.timeout ?
-                        config.timeout : default_cfg.timeout));
-        }
-        if (config.min_reply !== false) {
-            args.push(sys.format("-c %d",
-                        config.min_reply ?
-                        config.min_reply : default_cfg.min_reply));
-        }
-        if (config.extra !== false) {
-            args = args.concat(config.extra ?
-                    config.extra : default_cfg.extra);
-        }
-        args.push(addr);
+        args = linuxBuilder.getResult(addr, config);
         ls = cp.spawn('/bin/ping', args);
     } else if (p.match(/^win/)) {
         //windows
-        args = ['-n', '1', '-w', '5000'];
-        //TODO: No idea for how to write ping commands in Window
-        if (config.extra !== false) {
-            args = args.concat(config.extra ?
-                    config.extra : default_cfg.extra);
-        }
-        args.push(addr);
+        args = winBuilder.getResult(addr, config);
         ls = cp.spawn(process.env.SystemRoot + '/system32/ping.exe', args);
     } else if (p === 'darwin' || p === 'freebsd') {
-        // Mac OS X or FreeBSD
-        args = [];
-        if (config.numeric !== false) {
-            args.push("-n");
-        }
-        if (config.timeout !== false) {
-            args.push(sys.format("-t %d",
-                                 config.timeout ?
-                                 config.timeout : default_cfg.timeout));
-        }
-        if (config.min_reply !== false) {
-            args.push(sys.format("-c %d",
-                                 config.min_reply ?
-                                 config.min_reply : default_cfg.min_reply));
-        }
-        if (config.extra !== false) {
-            args = args.concat(config.extra ?
-                               config.extra : default_cfg.extra);
-        }
-        args.push(addr);
+        //mac osx
+        args = macBuilder.getResult(addr, config);
         ls = cp.spawn('/sbin/ping', args);
-
     }
     ls.on('error', function (e) {
         var err = new Error(

--- a/lib/ping-promise.js
+++ b/lib/ping-promise.js
@@ -24,13 +24,9 @@ var winBuilder = require('./builder/win');
 /**
  * Class::PromisePing
  *
- * @param addr string
- * @param config dict
- * {
- *      options: [...]
- * }
- *
- * @return Class::Q promise
+ * @param {string} addr - Hostname or ip addres
+ * @param {PingConfig} config - Configuration for command ping
+ * @return {Promise}
  */
 function probe(addr, config) {
     var p = os.platform();

--- a/lib/ping-sys.js
+++ b/lib/ping-sys.js
@@ -13,82 +13,32 @@ var sys = require('util'),
     cp = require('child_process'),
     os = require('os');
 
+// Promise implementation
+var ping = require('./ping-promise');
+
+/**
+ * Callback after probing given host
+ * @callback probeCallback
+ * @param {boolean} isAlive - Whether target is alive or not
+ * @param {Object} error - Null if no error occurs
+ */
+
 /**
  * Class::Ping construtor
  *
- * @param addr string
- * @param cb function (data, err)
- *      arguments order is based on compatabile issue
+ * @param {string} addr - Hostname or ip addres
+ * @param {probeCallback} cb - Callback
+ * @param {PingConfig} config - Configuration for command ping
  */
-function probe(addr, cb) {
-        var p = os.platform();
-        var ls = null;
-        var outstring = "";
+function probe(addr, cb, config) {
+    // Do not reassign function parameter
+    var _config = config || {};
 
-        if (p === 'linux') {
-            //linux
-            ls = cp.spawn('/bin/ping', ['-n', '-w 2', '-c 1', addr]);
-        } else if (p.match(/^win/)) {
-            //windows
-            ls = cp.spawn(process.env.SystemRoot + '/system32/ping.exe', ['-n', '1', '-w', '5000', addr]);
-        } else if (p === 'darwin' || p === 'freebsd') {
-            // Mac OS X or FreeBSD
-            ls = cp.spawn('/sbin/ping', ['-n', '-t 2', '-c 1', addr]);
-        } else if (p == 'freebsd') {
-            //FreeBSD
-            ls = cp.spawn('/sbin/ping', ['-n', '-t 2', '-c 1', addr]);
-        } else if (p === 'freebsd') {
-            //freebsd
-            ls = cp.spawn('/sbin/ping', ['-n', '-t 2', '-c 1', addr])
-        }
-
-
-        ls.on('error', function (e) {
-            var err = new Error('ping.probe: there was an error while executing the ping program. check the path or permissions...');
-            cb(null, err);
-        });
-
-
-        ls.stdout.on('data', function (data) {
-            outstring += String(data);
-        });
-
-        ls.stderr.on('data', function (data) {
-          //sys.print('stderr: ' + data);
-        });
-
-        ls.on('exit', function (code) {
-            var result;
-            // workaround for windows machines
-            // if host is unreachable ping will return
-            // a successfull error code
-            // so we need to handle this ourself
-            if (p.match(/^win/)) {
-                var lines = outstring.split('\n');
-                result  = false;
-                for (var t = 0; t < lines.length; t++) {
-                    if (lines[t].search(/TTL=[0-9]+/i) > 0) {
-						result	= true;
-						break;
-					}
-                }
-                // below is not working on My Chinese Windows8 64bit
-                /*
-                for (var t = 0; t < lines.length; t++) {
-                    if (lines[t].match (/[0-9]:/)) {
-                        result = (lines[t].indexOf ("=") != -1);
-                        break;
-                    }
-                }
-                */
-            } else {
-                result = (code === 0) ? true : false;
-            }
-
-            if (cb) {
-                cb(result, null);
-            }
-        });
+    return ping.probe(addr, _config).then(function (res) {
+        cb(res.alive, null);
+    }).catch(function (err) {
+        cb(null, err);
+    }).done();
 }
 
 exports.probe = probe;


### PR DESCRIPTION
1. Set default arguments for running ping MAC so that it won't stuck as specified at #34 
2. Create builder for building arguments for ping commands in different platform