### PR TITLE
Added round-trip time to the result from ping.promise.

### DIFF
--- a/lib/ping-promise.js
+++ b/lib/ping-promise.js
@@ -103,7 +103,7 @@ function probe(addr, config) {
     **/
 
     ls.on('exit', function (code) {
-        var result;
+        var result, time;
         // workaround for windows machines
         // if host is unreachable ping will return
         // a successfull error code
@@ -131,10 +131,18 @@ function probe(addr, config) {
         else {
             result = (code === 0) ? true : false;
         }
+        for (var t = 0; t < lines.length; t++) {
+            var match = /time=([0-9\.]+)\s*ms/i.exec(lines[t]);
+            if (match) {
+                time = parseInt(match[1]);
+                break;
+            }
+        }
         deferred.resolve({
             host: addr,
             alive: result,
-            output: outstring
+            output: outstring,
+            time: time
         });
     });
     return deferred.promise;


### PR DESCRIPTION
Just a simple regex to pull out the "time=" part of the output. Works on at least windows and linux. If alive is false, time will be undefined.