### PR TITLE
Add basic IPv6 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Below is the possible configuration
  * @property {boolean} numeric - Map IP address to hostname or not
  * @property {number} timeout - Time duration for ping command to exit
  * @property {number} min_reply - Exit after sending number of ECHO_REQUEST
+ * @property {boolean} v6 - Ping via ipv6 or not. Default is false
  * @property {string[]} extra - Optional options does not provided
  */
 ```

--- a/lib/builder/factory.js
+++ b/lib/builder/factory.js
@@ -61,6 +61,7 @@ factory.isPlatformSupport = function (p) {
 /**
  * Return a path to the ping executable in the system
  * @param {string} platform - Name of the platform
+ * @param {bool} v6 - Ping via ipv6 or not
  * @return {object} - Argument builder
  * @throw if given platform is not supported
  */

--- a/lib/builder/factory.js
+++ b/lib/builder/factory.js
@@ -64,7 +64,7 @@ factory.isPlatformSupport = function (p) {
  * @return {object} - Argument builder
  * @throw if given platform is not supported
  */
-factory.getExecutablePath = function (platform) {
+factory.getExecutablePath = function (platform, v6) {
     if (!this.isPlatformSupport(platform)) {
         throw new Error(util.format('Platform |%s| is not support', platform));
     }
@@ -74,11 +74,11 @@ factory.getExecutablePath = function (platform) {
     if (platform === 'aix') {
         ret = '/usr/sbin/ping';
     } else if (factory.isLinux(platform)) {
-        ret = '/bin/ping';
+        ret = v6 ? '/sbin/ping6' : '/bin/ping';
     } else if (factory.isWindow(platform)) {
         ret = process.env.SystemRoot + '/system32/ping.exe';
     } else if (factory.isMacOS(platform)) {
-        ret = '/sbin/ping';
+        ret = v6 ? '/sbin/ping6' : '/sbin/ping';
     }
 
     return ret;

--- a/lib/builder/mac.js
+++ b/lib/builder/mac.js
@@ -49,7 +49,7 @@ builder.getResult = function (target, config) {
         ret.push('-n');
     }
 
-    if (_config.timeout) {
+    if (_config.timeout && !_config.v6) {
         ret = ret.concat([
             '-t',
             util.format('%d', _config.timeout),

--- a/lib/builder/win.js
+++ b/lib/builder/win.js
@@ -45,6 +45,8 @@ builder.getResult = function (target, config) {
         }
     });
 
+    ret.push(_config.v6 ? '-6' : '-4');
+
     if (!_config.numeric) {
         ret.push('-a');
     }

--- a/lib/parser/mac.js
+++ b/lib/parser/mac.js
@@ -36,7 +36,7 @@ MacParser.prototype._processBody = function (line) {
     // XXX: Assume there is at least 3 '=' can be found
     var count = (line.match(/=/g) || []).length;
     if (count >= 3) {
-        var regExp = /([0-9\.]+)[ ]*ms/;
+        var regExp = /([0-9.]+)[ ]*ms/;
         var match = regExp.exec(line);
         this._times.push(parseFloat(match[1], 10));
     }
@@ -53,9 +53,9 @@ MacParser.prototype._processBody = function (line) {
  */
 MacParser.prototype._processFooter = function (line) {
     // XXX: Assume number of keywords '/' more than 3
-    var count = (line.match(/[\/]/g) || []).length;
+    var count = (line.match(/[/]/g) || []).length;
     if (count >= 3) {
-        var regExp = /([0-9\.]+)/g;
+        var regExp = /([0-9.]+)/g;
         // XXX: Assume min avg max stddev
         var m1 = regExp.exec(line);
         var m2 = regExp.exec(line);

--- a/lib/parser/win.js
+++ b/lib/parser/win.js
@@ -80,7 +80,7 @@ WinParser.prototype._processBody = function (line) {
         var timeKVP = __.find(kvps, function (kvp) {
             return kvp.indexOf('ms') >= 0;
         });
-        var regExp = /([0-9\.]+)/;
+        var regExp = /([0-9.]+)/;
         var match = regExp.exec(timeKVP);
 
         this._times.push(parseFloat(match[1], 10));
@@ -100,7 +100,7 @@ WinParser.prototype._processFooter = function (line) {
     // XXX: Assume there is a keyword ms
     if (line.indexOf('ms') >= 0) {
         // XXX: Assume the ordering is Min Max Avg
-        var regExp = /([0-9\.]+)/g;
+        var regExp = /([0-9.]+)/g;
         var m1 = regExp.exec(line);
         var m2 = regExp.exec(line);
         var m3 = regExp.exec(line);

--- a/lib/ping-promise.js
+++ b/lib/ping-promise.js
@@ -42,7 +42,7 @@ function probe(addr, config) {
     var platform = os.platform();
     var argumentBuilder = builderFactory.createBuilder(platform);
     ping = cp.spawn(
-        builderFactory.getExecutablePath(platform, config.v6),
+        builderFactory.getExecutablePath(platform, _config.v6),
         argumentBuilder.getResult(addr, _config)
     );
 

--- a/lib/ping-promise.js
+++ b/lib/ping-promise.js
@@ -42,7 +42,7 @@ function probe(addr, config) {
     var platform = os.platform();
     var argumentBuilder = builderFactory.createBuilder(platform);
     ping = cp.spawn(
-        builderFactory.getExecutablePath(platform),
+        builderFactory.getExecutablePath(platform, config.v6),
         argumentBuilder.getResult(addr, _config)
     );
 


### PR DESCRIPTION
The following changes were made to support pinging IPv6 hosts:
  - On Linux and macOS, use `/sbin/ping6` as the executable
  - On macOS, if pinging an IPv6 host, don't pass a timeout argument