### PR TITLE
Add android support

### DIFF
--- a/lib/builder/factory.js
+++ b/lib/builder/factory.js
@@ -20,6 +20,7 @@ function factory() {}
 factory.isLinux = function (p) {
     var platforms = [
         'aix',
+        'android',
         'linux',
     ];
 

--- a/test/load-fixture-path.js
+++ b/test/load-fixture-path.js
@@ -9,6 +9,7 @@ var glob = require('glob');
 function isLinux(p) {
     var platforms = [
         'aix',
+        'android',
         'linux',
     ];
 

--- a/test/test-ping.js
+++ b/test/test-ping.js
@@ -24,12 +24,14 @@ var PLATFORMS = [
     'darwin',
     'freebsd',
     // 'aix',
+    'android',
     'linux',
 ];
 var PLATFORM_TO_EXTRA_ARGUMENTS = {
     window: ['-n', '2'],
     darwin: ['-c', '2'],
     freebsd: ['-c', '2'],
+    android: ['-c', '2'],
     linux: ['-c', '2'],
 };
 


### PR DESCRIPTION
 Many android devices do not have any terminal emulator pre-installed, but they have the `/system/bin/ping` and `/system/bin/ping6` binaries.
I have runned the tests on termux and all of them succeeded.