### PR TITLE
Improvement: package loss field added to PingResponse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,13 +47,14 @@ Value of that key should be the result from our command.
     "min": 4.269,
     "max": 4.96,
     "avg": 5.371,
+    "packageLoss": 0.0
     "stddev": 0.424
 }
 ```
 
 ## Running test cases
 
-We trust tesed codes. Please run below command for testing before sending
+We trust tested codes. Please run below command for testing before sending
 a pull request
 
 ```
@@ -65,4 +66,4 @@ $ grunt test
 As #67 introduces ipv6 mechanism, fixture file names with `v6` will enable v6.
 Please refer to window/de/v6_sample.txt for an example
 
-[1]: http://www.jsoneditoronline.org/
+[1]: https://jsoneditoronline.org

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Below is the possible configuration
  * @param {string} min - Minimum time for collection records
  * @param {string} max - Maximum time for collection records
  * @param {string} avg - Average time for collection records
+ * @param {number} packetLoss - Packet Losses in percent (number)
  * @param {string} stddev - Standard deviation time for collected records
  */
 ```

--- a/lib/builder/win.js
+++ b/lib/builder/win.js
@@ -12,7 +12,7 @@ var builder = {};
  * Cross platform config representation
  * @typedef {Object} PingConfig
  * @property {boolean} numeric - Map IP address to hostname or not
- * @property {number} timeout - Timeout in seconds for each individual ping request
+ * @property {number} timeout - Timeout in seconds for each ping request
  * @property {number} min_reply - Exit after sending number of ECHO_REQUEST
  * @property {boolean} v6 - Use IPv4 (default) or IPv6
  * @property {string} sourceAddr - source address for sending the ping

--- a/lib/parser/base.js
+++ b/lib/parser/base.js
@@ -15,6 +15,7 @@ var __ = require('underscore');
  * @param {string} min - Minimum time for collection records
  * @param {string} max - Maximum time for collection records
  * @param {string} avg - Average time for collection records
+ * @param {number} packetLoss - Packet Losses in percent (number)
  * @param {string} stddev - Standard deviation time for collected records
  */
 
@@ -52,6 +53,19 @@ function parser(config) {
     // Ping Config
     this._pingConfig = config || {};
 }
+
+/**
+ * @constructor
+ *
+ * @param {string} output - Output from ping response
+ * @return {number} - Packet Loss Percentual (in number)
+ */
+const getPacketLossPercentual = (output) => {
+    const regex = new RegExp(/([.\d]+)(%)/, 'm');
+    const matches = output.match(regex);
+    const packetLossPercent = matches && matches[1] && parseFloat(matches[1]);
+    return packetLossPercent;
+};
 
 /**
  * Enum for parser states
@@ -173,6 +187,8 @@ parser.prototype.getResult = function () {
             Math.sqrt(variances) * 1000
         ) / 1000;
     }
+
+    ret.packetLoss = getPacketLossPercentual(ret.output);
 
     // Fix min, avg, max, stddev up to 3 decimal points
     __.each(['min', 'avg', 'max', 'stddev'], function (key) {

--- a/test/fixture/answer.json
+++ b/test/fixture/answer.json
@@ -14,6 +14,7 @@
     "min": "4.269",
     "max": "5.371",
     "avg": "4.960",
+    "packetLoss": 0.0,
     "stddev": "0.424"
   },
   "linux_en_sample1": {
@@ -31,7 +32,46 @@
     "min": "0.022",
     "max": "0.030",
     "avg": "0.027",
+    "packetLoss": 0,
     "stddev": "0.003"
+  },
+  "linux_en_sample2": {
+    "host": "10.48.249.8",
+    "numeric_host": "10.48.249.8",
+    "alive": true,
+    "output": "PING 10.48.249.8 (10.48.249.8) 56(84) bytes of data.\n64 bytes from 10.48.249.8: icmp_seq=1 ttl=64 time=2.98 ms\n64 bytes from 10.48.249.8: icmp_seq=2 ttl=64 time=0.890 ms\n64 bytes from 10.48.249.8: icmp_seq=3 ttl=64 time=0.711 ms\n64 bytes from 10.48.249.8: icmp_seq=4 ttl=64 time=0.863 ms\n64 bytes from 10.48.249.8: icmp_seq=5 ttl=64 time=1.20 ms\nping: sendmsg: Network is unreachable\nping: sendmsg: Network is unreachable\nping: sendmsg: Network is unreachable\n64 bytes from 10.48.249.8: icmp_seq=14 ttl=64 time=797 ms\n64 bytes from 10.48.249.8: icmp_seq=15 ttl=64 time=3.86 ms\n64 bytes from 10.48.249.8: icmp_seq=16 ttl=64 time=1.62 ms\n64 bytes from 10.48.249.8: icmp_seq=17 ttl=64 time=0.702 ms\n64 bytes from 10.48.249.8: icmp_seq=18 ttl=64 time=0.783 ms\n64 bytes from 10.48.249.8: icmp_seq=19 ttl=64 time=0.646 ms\n\n--- 10.48.249.8 ping statistics ---\n19 packets transmitted, 11 received, 42% packet loss, time 18195ms\nrtt min/avg/max/mdev = 0.646/73.819/797.744/228.927 ms\n",
+    "time": 2.98,
+    "times": [
+      2.98,
+      0.89,
+      0.711,
+      0.863,
+      1.2,
+      797,
+      3.86,
+      1.62,
+      0.702,
+      0.783,
+      0.646
+    ],
+    "min": "0.646",
+    "max": "797.744",
+    "avg": "73.819",
+    "packetLoss": 42,
+    "stddev": "228.927"
+  },
+  "linux_en_sample3": {
+    "host": "10.48.249.150",
+    "numeric_host": "10.48.249.150",
+    "alive": false,
+    "output": "PING 10.48.249.150 (10.48.249.150) 56(84) bytes of data.\nFrom 10.48.249.95 icmp_seq=1 Destination Host Unreachable\nFrom 10.48.249.95 icmp_seq=2 Destination Host Unreachable\nFrom 10.48.249.95 icmp_seq=3 Destination Host Unreachable\n\n--- 10.48.249.150 ping statistics ---\n5 packets transmitted, 0 received, +3 errors, 100% packet loss, time 4079ms\n",
+    "time": "unknown",
+    "times": [],
+    "min": "unknown",
+    "max": "unknown",
+    "avg": "unknown",
+    "packetLoss": 100,
+    "stddev": "unknown"
   },
   "window_en_sample1": {
     "host": "www.some-domain.com",
@@ -48,6 +88,7 @@
     "min": "548.000",
     "max": "564.000",
     "avg": "555.000",
+    "packetLoss": 0,
     "stddev": "5.723"
   },
   "window_fr_sample1": {
@@ -65,6 +106,7 @@
     "min": "0.000",
     "max": "0.000",
     "avg": "0.000",
+    "packetLoss": 0,
     "stddev": "1.000"
   },
   "window_fr_sample2": {
@@ -82,6 +124,7 @@
     "min": "6.000",
     "max": "6.000",
     "avg": "6.000",
+    "packetLoss": 0,
     "stddev": "0.000"
   },
   "window_ja_sample1": {
@@ -99,6 +142,7 @@
     "min": "4.000",
     "max": "7.000",
     "avg": "5.000",
+    "packetLoss": 0,
     "stddev": "1.225"
   },
   "window_ja_sample2": {
@@ -116,6 +160,7 @@
     "min": "4.000",
     "max": "6.000",
     "avg": "4.000",
+    "packetLoss": 0,
     "stddev": "1.118"
   },
   "window_zh_sample1": {
@@ -133,6 +178,7 @@
     "min": "2.000",
     "max": "3.000",
     "avg": "2.000",
+    "packetLoss": 0,
     "stddev": "0.707"
   },
   "window_zh_sample2": {
@@ -150,6 +196,7 @@
     "min": "2.000",
     "max": "3.000",
     "avg": "2.000",
+    "packetLoss": 0,
     "stddev": "0.707"
   },
   "window_zh_sample3": {
@@ -167,6 +214,7 @@
     "min": "0.000",
     "max": "0.000",
     "avg": "0.000",
+    "packetLoss": 0,
     "stddev": "1.000"
   },
   "window_ru_sample1": {
@@ -184,6 +232,7 @@
     "min": "33.000",
     "max": "38.000",
     "avg": "35.000",
+    "packetLoss": 0,
     "stddev": "2.121"
   },
   "window_de_v6_sample": { "host": "google.de",
@@ -199,6 +248,7 @@
     "min": "11.000",
     "max": "18.000",
     "avg": "12.000",
+    "packetLoss": 0,
     "stddev": "3.122",
     "numeric_host": "2a00:1450:4001:810::2003" }
 }

--- a/test/fixture/linux/en/sample2.txt
+++ b/test/fixture/linux/en/sample2.txt
@@ -1,0 +1,19 @@
+PING 10.48.249.8 (10.48.249.8) 56(84) bytes of data.
+64 bytes from 10.48.249.8: icmp_seq=1 ttl=64 time=2.98 ms
+64 bytes from 10.48.249.8: icmp_seq=2 ttl=64 time=0.890 ms
+64 bytes from 10.48.249.8: icmp_seq=3 ttl=64 time=0.711 ms
+64 bytes from 10.48.249.8: icmp_seq=4 ttl=64 time=0.863 ms
+64 bytes from 10.48.249.8: icmp_seq=5 ttl=64 time=1.20 ms
+ping: sendmsg: Network is unreachable
+ping: sendmsg: Network is unreachable
+ping: sendmsg: Network is unreachable
+64 bytes from 10.48.249.8: icmp_seq=14 ttl=64 time=797 ms
+64 bytes from 10.48.249.8: icmp_seq=15 ttl=64 time=3.86 ms
+64 bytes from 10.48.249.8: icmp_seq=16 ttl=64 time=1.62 ms
+64 bytes from 10.48.249.8: icmp_seq=17 ttl=64 time=0.702 ms
+64 bytes from 10.48.249.8: icmp_seq=18 ttl=64 time=0.783 ms
+64 bytes from 10.48.249.8: icmp_seq=19 ttl=64 time=0.646 ms
+
+--- 10.48.249.8 ping statistics ---
+19 packets transmitted, 11 received, 42% packet loss, time 18195ms
+rtt min/avg/max/mdev = 0.646/73.819/797.744/228.927 ms

--- a/test/fixture/linux/en/sample3.txt
+++ b/test/fixture/linux/en/sample3.txt
@@ -1,0 +1,7 @@
+PING 10.48.249.150 (10.48.249.150) 56(84) bytes of data.
+From 10.48.249.95 icmp_seq=1 Destination Host Unreachable
+From 10.48.249.95 icmp_seq=2 Destination Host Unreachable
+From 10.48.249.95 icmp_seq=3 Destination Host Unreachable
+
+--- 10.48.249.150 ping statistics ---
+5 packets transmitted, 0 received, +3 errors, 100% packet loss, time 4079ms

--- a/test/test-ping.js
+++ b/test/test-ping.js
@@ -192,7 +192,7 @@ describe('ping timeout and deadline options', function () {
             }).then(function () {
                 const spawnArgs = this.spawnStub.getCalls()[0].args;
                 const pingArgs = spawnArgs[1];
-                expect(pingArgs[pingArgs.indexOf('-W') + 1]).to.equal('4700');
+                expect(pingArgs[pingArgs.indexOf('-W') + 1]).to.equal('47000');
                 expect(pingArgs[pingArgs.indexOf('-t') + 1]).to.equal('83');
             }.bind(this));
         });


### PR DESCRIPTION
Hi @danielzzz. How are you Doing?

I hope well!

As requested on issue #85, in some cases We want to know How much packages has been lost at ping action. So, this pull request aims to add on PingResponse object a field called packageLoss Who holds this percentage.

How this Could helps:

Sometimes We want to set some tolerance for errors. With that property you Could (for example) report that internet is unstable.

Other informations:

- fixed some mispelling at CONTRIBUTIONS.md
- fixed a broken link at CONTRIBUTIONS.md
- adjusted line length for testing pass at win.js file
- adjusted ping binary test scenario
- adjusted answer.json with the new property
- added two new fixtures with failling context (100% package failure and partial package failure)
- expected output at CONTRIBUTION.md file was updated
- updated parsed response explanation at README.md

Related: https://github.com/danielzzz/node-ping/issues/85