### PR TITLE
Fix #129 parsing error of ping results on linux

### DIFF
--- a/lib/builder/linux.js
+++ b/lib/builder/linux.js
@@ -118,6 +118,7 @@ builder.getCommandArguments = function (target, config) {
 builder.getSpawnOptions = function () {
     return {
         shell: true,
+        env: Object.assign(process.env, {LANG: 'C'}),
     };
 };
 


### PR DESCRIPTION
## Summary
As title says, this patch fix parsing error (#129) of ping results on linux with Japanese locale.
I'm not sure about Mac OS X, but I think this is linux specific issue.