### PR TITLE
Fix #125 hide command prompt window on windows

### DIFF
--- a/lib/builder/win.js
+++ b/lib/builder/win.js
@@ -111,7 +111,9 @@ builder.getCommandArguments = function (target, config) {
  * @return {object} - Refer to document of child_process.spawn
  */
 builder.getSpawnOptions = function () {
-    return {};
+    return {
+        windowsHide: true,
+    };
 };
 
 module.exports = builder;


### PR DESCRIPTION
## Summary
This patch prevent opening command prompt window in pm2 on Windows environment.