### PR TITLE
Add support for verifying reply addresses (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ Below is the possible configuration
  * @property {string} sourceAddr - source address for sending the ping
  * @property {number} packetSize - Specifies the number of data bytes to be sent
                                    Default: Linux / MAC: 56 Bytes, Windows: 32 Bytes
+ * @property {boolean} verifyReplyAddress - Enables verification of reply addresses,
+ *                                          Default: Linux: false
+ *                                          Other platforms do not need this option.
+ * If set to true and a reply is received from an address which does not match the parsed
+ * `PingResponse.numeric_host`, the ping response is ignored.
+ * This helps against detecting a host as alive by accident when another host replies to the ping.
+ * This workaround addresses an imperfection in the ping implementation within the package iputils.
  * @property {string[]} extra - Optional options does not provided
  */
 ```

--- a/lib/builder/linux.js
+++ b/lib/builder/linux.js
@@ -27,6 +27,13 @@ var builder = {};
  * @property {number} packetSize - Specifies the number of data bytes to be sent
  *                                 Default: Linux / MAC: 56 Bytes,
  *                                          Window: 32 Bytes
+ * @property {boolean} verifyReplyAddress - Enables verification of reply addresses,
+ *                                          Default: Linux: false
+ *                                          Other platforms do not need this option.
+ * If set to true and a reply is received from an address which does not match the parsed
+ * `PingResponse.numeric_host`, the ping response is ignored.
+ * This helps against detecting a host as alive by accident when another host replies to the ping.
+ * This workaround addresses an imperfection in the ping implementation within the package iputils.
  * @property {string[]} extra - Optional options does not provided
  */
 
@@ -38,6 +45,7 @@ var defaultConfig = {
     v6: false,
     sourceAddr: '',
     packetSize: 56,
+    verifyReplyAddress: false,
     extra: [],
 };
 
@@ -55,7 +63,7 @@ builder.getCommandArguments = function (target, config) {
 
     // Make every key in config has been setup properly
     var keys = ['numeric', 'timeout', 'deadline', 'min_reply', 'v6',
-        'sourceAddr', 'extra', 'packetSize'];
+        'sourceAddr', 'extra', 'packetSize', 'verifyReplyAddress'];
     keys.forEach(function (k) {
         // Falsy value will be overridden without below checking
         if (typeof(_config[k]) !== 'boolean') {

--- a/lib/parser/mac.js
+++ b/lib/parser/mac.js
@@ -38,7 +38,12 @@ MacParser.prototype._processBody = function (line) {
     if (count >= 3) {
         var regExp = /([0-9.]+)[ ]*ms/;
         var match = regExp.exec(line);
-        this._times.push(parseFloat(match[1], 10));
+        // XXX: This option is only provided in linux builder, but the parser is shared.
+        // This option should have no effect on macOS,
+        // as ping on macOS does not accept replies from a different address
+        if (!this._pingConfig.verifyReplyAddress || line.includes(this._response.numeric_host)) {
+            this._times.push(parseFloat(match[1], 10));
+        }
     }
 
     // Change state if it see a '---'

--- a/test/fixture/answer.json
+++ b/test/fixture/answer.json
@@ -91,6 +91,25 @@
     "packetLoss": "100.000",
     "stddev": "unknown"
   },
+  "linux_en_sample_reply_from_different_address": {
+    "inputHost": "whatever",
+    "host": "192.168.178.1",
+    "numeric_host": "192.168.178.1",
+    "alive": true,
+    "output": "PING 192.168.178.1 (192.168.178.1) 56(84) bytes of data.\n64 bytes from 192.168.178.8: icmp_seq=1 ttl=64 time=0.578 ms (DIFFERENT ADDRESS!)\n64 bytes from 192.168.178.8: icmp_seq=2 ttl=64 time=0.348 ms (DIFFERENT ADDRESS!)\n64 bytes from 192.168.178.8: icmp_seq=3 ttl=64 time=0.994 ms (DIFFERENT ADDRESS!)\n64 bytes from 192.168.178.8: icmp_seq=4 ttl=64 time=0.349 ms (DIFFERENT ADDRESS!)\n\n--- 192.168.178.1 ping statistics ---\n4 packets transmitted, 4 received, 0% packet loss, time 3004ms\nrtt min/avg/max/mdev = 0.348/0.567/0.994/0.263 ms",
+    "time": 0.578,
+    "times": [
+      0.578,
+      0.348,
+      0.994,
+      0.349
+    ],
+    "min": "0.348",
+    "max": "0.994",
+    "avg": "0.567",
+    "stddev": "0.263",
+    "packetLoss": "0.000"
+  },
   "linux_en_v6_sample1": {
     "inputHost": "whatever",
     "host": "2606:4700:4700::1111",

--- a/test/fixture/linux/en/sample_reply_from_different_address.txt
+++ b/test/fixture/linux/en/sample_reply_from_different_address.txt
@@ -1,0 +1,9 @@
+PING 192.168.178.1 (192.168.178.1) 56(84) bytes of data.
+64 bytes from 192.168.178.8: icmp_seq=1 ttl=64 time=0.578 ms (DIFFERENT ADDRESS!)
+64 bytes from 192.168.178.8: icmp_seq=2 ttl=64 time=0.348 ms (DIFFERENT ADDRESS!)
+64 bytes from 192.168.178.8: icmp_seq=3 ttl=64 time=0.994 ms (DIFFERENT ADDRESS!)
+64 bytes from 192.168.178.8: icmp_seq=4 ttl=64 time=0.349 ms (DIFFERENT ADDRESS!)
+
+--- 192.168.178.1 ping statistics ---
+4 packets transmitted, 4 received, 0% packet loss, time 3004ms
+rtt min/avg/max/mdev = 0.348/0.567/0.994/0.263 ms

--- a/test/test-ping.js
+++ b/test/test-ping.js
@@ -127,6 +127,39 @@ var createTestCase = function (platform, pingExecution) {
     });
 };
 
+describe('ping reply from a different address', function () {
+    describe('on linux platform', function() {
+        beforeEach(function() {
+            this.platformStub = sinon.stub(os, 'platform').callsFake(function() {
+                return 'linux';
+            });
+            const fixturePath = path.join(__dirname, 'fixture', 'linux', 'en', 'sample_reply_from_different_address.txt');
+            this.spawnStub = sinon.stub(cp, 'spawn').callsFake(mockOutSpawn(fixturePath));
+        });
+
+        afterEach(function() {
+            this.platformStub.restore();
+            this.spawnStub.restore();
+        });
+
+        it('host is not considered alive if verifyReplyAddress is true', async function() {
+            const res = await ping.promise
+                .probe('whatever', {
+                    verifyReplyAddress: true,
+                });
+            expect(res.alive).to.be.false;
+        });
+
+        it('host is considered alive if verifyReplyAddress is false', async function() {
+            const res = await ping.promise
+                .probe('whatever', {
+                    verifyReplyAddress: false,
+                });
+            expect(res.alive).to.be.true;
+        });
+    });
+});
+
 describe('ping timeout and deadline options', function () {
     describe('on linux platform', function () {
         beforeEach(function () {


### PR DESCRIPTION
On linux platform when using ping from iptuils there is an issue when some misbehaving hosts or other network devices may respond to a ping with a different address. The ping implementation of `iputils` unfortunately regards those as valid replies and prints the timing information nevertheless see: [comparison of source address with target](https://github.com/iputils/iputils/blob/e6cc75f5d17be59377252b4613938edc2cfc7bef/ping/ping.c#L1692) and the corresponding [statistics output](https://github.com/iputils/iputils/blob/e6cc75f5d17be59377252b4613938edc2cfc7bef/ping/ping_common.c#L857)

We observed an issues with host being detected as alive when another misbehaving hosts replies to the echo requests. This PR Addresses the issue by adding an option to enable verification of reply addresses.

---------